### PR TITLE
apt install procps, because ps cmd is used and not found by hadoop daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV HADOOP_HOME=/usr/local/hadoop-$HADOOP_VERSION
 # Install dependencies
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install \
-    -yq --no-install-recommends netcat \
+    -yq --no-install-recommends netcat procps \
   && apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Logs noticed when starting the container: 
```Starting namenodes on [5530126f9fb3]
starting namenode, logging to /usr/local/hadoop-2.7.4/logs/hadoop-root-namenode-5530126f9fb3.out
/usr/local/hadoop-2.7.4/sbin/hadoop-daemon.sh: line 181: ps: command not found
starting datanode, logging to /usr/local/hadoop-2.7.4/logs/hadoop-root-datanode-5530126f9fb3.out
/usr/local/hadoop-2.7.4/sbin/hadoop-daemon.sh: line 181: ps: command not found
Starting secondary namenodes [0.0.0.0]
starting secondarynamenode, logging to /usr/local/hadoop-2.7.4/logs/hadoop-root-secondarynamenode-5530126f9fb3.out
/usr/local/hadoop-2.7.4/sbin/hadoop-daemon.sh: line 181: ps: command not found
```

This should be applied to both 2.7 and 2.8. branches.